### PR TITLE
Rewrite equation for adjoint derivative.

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1131,7 +1131,7 @@ Using the same notation as for the directional derivatives for the different sta
 
 [latexmath]
 ++++
-\Delta \mathbf{v}_{known} = \left( \frac{\partial \mathbf{h}}{\partial \mathbf{v}_{known}} \right)^T \Delta \mathbf{v}_{unknown}
+\Delta \mathbf{v}_{known}^T = \Delta \mathbf{v}_{unknown}^T \left( \frac{\partial \mathbf{h}}{\partial \mathbf{v}_{known}} \right)
 ++++
 
 [[fmi3GetAdjointDerivative,`fmi3GetAdjointDerivative()`]]


### PR DESCRIPTION
The text a few lines above defines the adjoint derivative as a
transposed vector multiplied from left to the jacobian. But the equation
here defines it as a vector multiplied from right to the transposed
jacobian. Both represenations are mathematically equally but for
convinience the text and the equation should be analog.
I see the form transposed vector multiplied from left to the jacobian
the more natrual one. That's why I switch to this form consistently.

We can also go the other way around but it should be consistent in text and equation, I think.