### PR TITLE
Fixed parameter names in document

### DIFF
--- a/docs/2_1_common_api.adoc
+++ b/docs/2_1_common_api.adoc
@@ -1143,12 +1143,12 @@ include::../headers/fmi3FunctionTypes.h[tags=GetAdjointDerivative]
 - Parameter `unknowns` contains the value references of the unknown variables.
 The number of value references is given by the argument `nUnknowns`.
 
-- Parameter `known` contains the value references of the known variables.
-The number of value references is given by the argument `nKnown`.
+- Parameter `knowns` contains the value references of the known variables.
+The number of value references is given by the argument `nKnowns`.
 
 - Parameter `deltaUnknowns` and `deltaKnowns` contain the serialized values of the referenced variables (serialization of values as defined in <<get-and-set-variable-values>>).
 
-- Parameter `nDeltaUnknowns` provides the number of values in `deltaUnknowns` which is only equal to `nUnknowns` if all value references of `unknowns` point to scalar variables.
+- Parameter `nDeltaOfUnknowns` provides the number of values in `deltaUnknowns` which is only equal to `nUnknowns` if all value references of `unknowns` point to scalar variables.
 
 - Parameter `nDeltaKnowns` provides the number of values in `deltaKnowns` which is only equal to `nKnowns` if all value references of `knowns` point to scalar variables.
 


### PR DESCRIPTION
The names of c-API function paramters were not consistent with the
parameter names in the c-API functions.
Fixed now.